### PR TITLE
fix: correct ghUrl syntax in README Cloudflare Worker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export default {
 
     const url = new URL(request.url);
     const filePath = "output" + url.pathname;
-    const ghUrl = "[https://raw.githubusercontent.com/](https://raw.githubusercontent.com/)" + OWNER + "/" + REPO + "/" + BRANCH + "/" + filePath;
+    const ghUrl = "https://raw.githubusercontent.com/" + OWNER + "/" + REPO + "/" + BRANCH + "/" + filePath;
     
     const res = await fetch(ghUrl, {
       headers: {


### PR DESCRIPTION
## 问题描述

README 中 Cloudflare Worker 示例代码的第 97 行存在语法错误：

**错误代码：**
```javascript
const ghUrl = "[https://raw.githubusercontent.com/](https://raw.githubusercontent.com/)" + OWNER + "/" + REPO + "/" + BRANCH + "/" + filePath;
```

这是 Markdown 链接语法 `[text](url)` 被错误地写入了 JavaScript 代码块中，导致：
- JavaScript 语法错误（无法直接运行）
- `ghUrl` 变量的值包含多余的方括号和括号，拼接后的 URL 不正确

## 修复内容

将错误的 Markdown 链接格式修正为正确的 JavaScript 字符串：

**正确代码：**
```javascript
const ghUrl = "https://raw.githubusercontent.com/" + OWNER + "/" + REPO + "/" + BRANCH + "/" + filePath;
```

## 检查范围

已检查 README 全文，仅此一处存在此类 Markdown 链接语法误入代码块的问题。

## 影响

修复后，Cloudflare Worker 示例代码可以直接复制使用，无需手动修正 URL。